### PR TITLE
feat(pkg): install from branch and subdirectory

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -304,6 +304,14 @@ pub struct InstallArgs {
     #[arg(num_args = 1..)]
     pub url: String,
 
+    /// The branch you want to install a package from.
+    #[arg(short, long)]
+    pub branch: Option<String>,
+
+    /// The subdirectory you want to install a package from.
+    #[arg(short, long)]
+    pub subdir: Option<String>,
+
     /// The namespace you want to put your installed package. Default to local
     #[arg(short, long)]
     pub namespace: Option<String>,

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -49,7 +49,6 @@ pub async fn run(cmd: &InstallArgs) -> Result<bool> {
 
     // If a URL is provided, clone or copy the repository.
     fs::create_dir_all(&path)?;
-
     project().lock().unwrap().0 = path.clone();
 
     let url = &cmd.url;
@@ -68,12 +67,10 @@ pub async fn run(cmd: &InstallArgs) -> Result<bool> {
     }
 
     // Modify path if a subdirectory was specified so that manifest can be found.
-    // Trimming starting slash is necessary otherwise Rust treats it as absolute path
-    // but Git needs the starting slash for sparse-checkout.
-    let path = if let Some(s) = &cmd.subdir {
-        path.join(s.trim_start_matches('/'))
-    } else {
-        path
+    // Trimming starting slash is necessary otherwise Rust treats it as absolute path.
+    let path = match &cmd.subdir {
+        Some(s) => path.join(s.trim_start_matches('/')),
+        _ => path,
     };
 
     // Check for a manifest file in the source directory.

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::{
         copy_dir_all,
         dryrun::get_dry_run,
-        git::{clone_git, exist_git, project},
+        git::{clone_git, exist_git, project, sparse_checkout_git},
         paths::{MANIFEST_FILE, check_path_dir, check_path_file, package_path, utpm_data_path},
         state::Result,
         try_find,
@@ -56,15 +56,34 @@ pub async fn run(cmd: &InstallArgs) -> Result<bool> {
 
     // Handle git and http(s) URLs.
     if url.starts_with("git") || url.starts_with("http") {
-        clone_git(url, &path.to_string_lossy())?;
+        // If a subdirectory was specified, perform a sparse checkout instead.
+        if let Some(subdir) = &cmd.subdir {
+            sparse_checkout_git(url, &path.to_string_lossy(), subdir, cmd.branch.as_deref())?;
+        } else {
+            clone_git(url, &path.to_string_lossy(), cmd.branch.as_deref())?;
+        }
     } else {
         // Handle local paths.
         copy_dir_all(url, &path)?;
     }
+
+    // Modify path if a subdirectory was specified so that manifest can be found.
+    // Trimming starting slash is necessary otherwise Rust treats it as absolute path
+    // but Git needs the starting slash for sparse-checkout.
+    let path = if let Some(s) = &cmd.subdir {
+        path.join(s.trim_start_matches('/'))
+    } else {
+        path
+    };
+
     // Check for a manifest file in the source directory.
     let typstfile = path.join(MANIFEST_FILE);
     if !check_path_file(&typstfile) {
-        utpm_log!("{}", format!("x {}", url));
+        utpm_log!(
+            "{} (no manifest found at {:?})",
+            format!("x {}", url),
+            typstfile
+        );
         return Ok(false);
     }
 

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -115,7 +115,7 @@ pub async fn run(cmd: &PublishArgs) -> Result<bool> {
 
     match pull_git() {
         Ok(_) => Ok(true),
-        Err(_) => clone_git(&packages_path.to_string_lossy(), fork.as_str()),
+        Err(_) => clone_git(&packages_path.to_string_lossy(), fork.as_str(), None),
     }?;
     utpm_log!(
         info,

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -91,21 +91,26 @@ pub fn pull_git() -> Result<bool> {
     }
 }
 
-/// Run `git clone <url> <path>` in the project directory.
+/// Run `git clone [-b <branch>] <url> <path>` in the project directory.
 ///
 /// Arguments:
 /// - `string`: repository URL.
 /// - `path`: destination path (relative to project dir or absolute).
+/// - `branch`: optional branch to clone from.
 ///
 /// Returns Ok(true) if the process launches; categorized errors otherwise.
-pub fn clone_git(string: &str, path: &str) -> Result<bool> {
-    match Command::new("git")
+pub fn clone_git(string: &str, path: &str, branch: Option<&str>) -> Result<bool> {
+    let mut command = Command::new("git");
+    let mut clone_command = command
         .current_dir(&project().lock().unwrap().0)
-        .arg("clone")
-        .arg(string)
-        .arg(path)
-        .status()
-    {
+        .arg("clone");
+
+    // Add `-b <branch>` if one is specified.
+    if let Some(branch) = branch {
+        clone_command = clone_command.arg("-b").arg(branch).arg("--single-branch");
+    }
+
+    match clone_command.arg(string).arg(path).status() {
         Ok(_) => Ok(true),
         Err(e) => {
             utpm_bail!(Git, e.to_string())
@@ -145,5 +150,60 @@ pub fn commit_git(msg: &str) -> Result<bool> {
         Err(e) => {
             utpm_bail!(Git, e.to_string())
         },
+    }
+}
+
+/// Run a combination of `git clone --filter` + `git sparse-checkout` in the project directory.
+///
+/// Arguments:
+/// - `string`: repository URL.
+/// - `path`: destination path (relative to project dir or absolute).
+/// - `subdir`: subdirectory to clone.
+/// - `branch`: specific branch to checkout from.
+///
+/// Returns Ok(true) if the process launches; categorized errors otherwise.
+pub fn sparse_checkout_git(
+    string: &str,
+    path: &str,
+    subdir: &str,
+    branch: Option<&str>,
+) -> Result<bool> {
+    // https://stackoverflow.com/questions/600079/how-do-i-clone-a-subdirectory-only-of-a-git-repository/52269934#52269934
+    // Step 1: Clone with filter and optional branch.
+    let mut command = Command::new("git");
+    let clone_cmd = command
+        .current_dir(&project().lock().unwrap().0)
+        .arg("clone")
+        .arg(string)
+        .arg(path)
+        .arg("--no-checkout")
+        .arg("--depth=1")
+        .arg("--filter=tree:0");
+
+    // Add `-b <branch>` if one is specified.
+    let clone = if let Some(branch) = branch {
+        clone_cmd.args(["-b", branch, "--single-branch"]).status()
+    } else {
+        clone_cmd.status()
+    };
+
+    // Step 2: Sparse checkout in repository directory and match on subdirectory.
+    let sparse_checkout = Command::new("git")
+        .current_dir(PathBuf::from(path))
+        .arg("sparse-checkout")
+        .arg("set")
+        .arg("--no-cone")
+        .arg(subdir)
+        .status();
+
+    // Step 3: Do final checkout.
+    match clone.and(sparse_checkout).and_then(|_| {
+        Command::new("git")
+            .current_dir(PathBuf::from(path))
+            .arg("checkout")
+            .status()
+    }) {
+        Ok(_) => Ok(true),
+        Err(e) => utpm_bail!(Git, e.to_string()),
     }
 }


### PR DESCRIPTION
Allows to install a local package from a branch and/or a sub-directory of a git repository.

Adds two new flags to the `pkg install` sub-command:
- `--branch`/`-b` to specify the branch to clone from
- `--subdir`/`-s` to specify a relative path to a sub-directory inside the repository

Slightly modifies the `clone_git` function by adding an optional branch parameter, such that the command resolves to `git clone -b <branch> --single-branch <URL>` if a branch is specified. The `--single-branch` ensures that no other branches are fetched.

For `--subdir`, I used a combination of `git clone filter` and `git sparse-checkout` as described in this [SO thread](https://stackoverflow.com/questions/600079/how-do-i-clone-a-subdirectory-only-of-a-git-repository/52269934#52269934).

I have not done extensive testing yet but it has worked in my preliminary testing.